### PR TITLE
Use Path.GetFullPath() to correct platform-specific directory separator chars

### DIFF
--- a/src/SetStartupProjects/SolutionProjectExtractor.cs
+++ b/src/SetStartupProjects/SolutionProjectExtractor.cs
@@ -18,7 +18,7 @@ public static class SolutionProjectExtractor
             var strings = line.Split(["\", \""], StringSplitOptions.RemoveEmptyEntries);
             var guidType = strings[0].Split('{', '}')[1];
             var guid = strings[2].Trim('{', '}', '"');
-            var fullPath = Path.Combine(solutionDirectory, strings[1]);
+            var fullPath = Path.GetFullPath(Path.Combine(solutionDirectory, strings[1]));
             if (guidType == "2150E333-8FDC-42A3-9474-1A3956D46DE8")
             {
                 //this is a Solution Folder and can be ignored


### PR DESCRIPTION
The sln file will have `ProjectName\ProjectName.csproj` no matter the platform, but on a non-Windows host, with only Path.Combine, it will not handle the directory separator char correctly:

```
System.ArgumentException : File does not exist: /<root-path>/Shared\Shared.csproj (Parameter 'Project')
   at Guard.AgainstNonExistingFile(String file, String argumentName) in /_/src/SetStartupProjects/Guard.cs:line 17
   at SetStartupProjects.StartProjectFinder.ShouldIncludeProjectFile(Project project) in /_/src/SetStartupProjects/StartProjectFinder.cs:line 88
   at SetStartupProjects.StartProjectFinder.<GuessStartupProjects>b__0_0(Project project) in /_/src/SetStartupProjects/StartProjectFinder.cs:line 47
…
```

The addition of `Path.GetFullPath(…)` normalizes the directory separator chars for whatever platform it's running on.

Tests should still pass on Windows, but if run on Linux/Mac would not, because the slashes would be the opposite of the approval file. Looked at the Verify test but not sure how to attack that. Could do a scrubber to change all `/` to `\` but I'm not sure that would prove much or guard against regression. Or could go go platform-specific approval files. Figured I'd ask which you prefer, or if you have a different preferred approach.